### PR TITLE
fix: enable PebbleDB in single-tenant mode

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,7 +15,7 @@ import (
 
 // Server provides HTTP API for remote event storage
 type Server struct {
-	store       *store.SQLiteStore
+	store       store.EventStore
 	apiKey      string
 	mux         *http.ServeMux
 	rateLimiter *rateLimiter
@@ -38,7 +38,7 @@ func DefaultConfig() *Config {
 }
 
 // New creates a new event storage server (deprecated: use NewWithConfig)
-func New(store *store.SQLiteStore) *Server {
+func New(store store.EventStore) *Server {
 	apiKey := os.Getenv("API_KEY")
 	if apiKey == "" {
 		log.Fatal("API_KEY environment variable must be set")
@@ -47,7 +47,7 @@ func New(store *store.SQLiteStore) *Server {
 }
 
 // NewWithConfig creates a server with custom configuration
-func NewWithConfig(store *store.SQLiteStore, config *Config, apiKey string) *Server {
+func NewWithConfig(store store.EventStore, config *Config, apiKey string) *Server {
 	s := &Server{
 		store:       store,
 		apiKey:      apiKey,


### PR DESCRIPTION
## Summary

Fixes single-tenant mode to respect  environment variable. Previously it was hardcoded to SQLite.

## Problem

Single-tenant mode ignored the  configuration and always created a SQLiteStore, meaning deployments couldn't use PebbleDB unless running in multi-tenant mode.

## Solution

- Check  and create appropriate store (SQLite or PebbleDB)
- Update Server type to use  interface
- Add logging to show which backend is being used

## Deployment Impact

After this fix, to switch from SQLite to PebbleDB:
- Set  
- Set  (directory, not .db file)
- Fresh PebbleDB will start at position 0

**Note**: This will create a NEW empty database. Existing SQLite data at  will not be migrated.